### PR TITLE
fix: BaseEntity 가 제대로 동작하도록 @EnableJpaAuditing 추가

### DIFF
--- a/src/main/java/com/tm/gogo/GogoApplication.java
+++ b/src/main/java/com/tm/gogo/GogoApplication.java
@@ -2,7 +2,9 @@ package com.tm.gogo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class GogoApplication {
 

--- a/src/main/java/com/tm/gogo/domain/BaseEntity.java
+++ b/src/main/java/com/tm/gogo/domain/BaseEntity.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 public class BaseEntity {
 
     @CreatedDate
-    @Column(name = "created_at")
+    @Column(name = "created_at", updatable = false)
     protected LocalDateTime createdAt;
 
     @LastModifiedDate


### PR DESCRIPTION
## Issue

- Entity 값을 저장할 때 `createdAt`, `updatedAt` 이 제대로 동작하지 않음

## Description

저번에 급하게 올리느라 설명이 없었어서 간단하게 추가해봅니다.

이전 PR #7  에서 추가한 `BaseEntity` 는 Entity 를 저장, 수정할 때마다 매번 `createdAt`, `updatedAt` 세팅을 해줘야 합니다.

그리고 이 동작은 모든 Entity 에서 발생하기 때문에 엄청난 중복 코드 (보일러 플레이트) 를 만들게 됩니다.

그래서 JPA 에서는 Auditing 이라는 기능을 제공합니다.

우리말로 하면 감시라는 뜻인데 이름 그대로 Entity 를 감시하면서 특정 동작을 수행하게 하는 기능입니다.

감시를 원하는 클래스에 `@EntityListeners(AuditingEntityListener.class)` 를 붙이고 원하는 컬럼에 `@CreatedDate`, `@LastModifiedDate` 등의 어노테이션을 붙이면 됩니다.

자세한 내용은 검색해보세요