### PR TITLE
feat: #30 QueryDSL 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,13 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'org.springframework.boot' version '2.7.1'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
     id 'java'
 }
 
@@ -26,6 +33,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
@@ -38,4 +47,23 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+sourceSets {
+    main.java.srcDir querydslDir
+}
+compileQuerydsl{
+    options.annotationProcessorPath = configurations.querydsl
+}
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    querydsl.extendsFrom compileClasspath
 }

--- a/src/main/java/com/tm/gogo/config/QueryDslConfig.java
+++ b/src/main/java/com/tm/gogo/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.tm.gogo.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+
+    private final EntityManager em;
+
+    @Bean
+    public JPAQueryFactory queryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/tm/gogo/domain/RecommendTrail.java
+++ b/src/main/java/com/tm/gogo/domain/RecommendTrail.java
@@ -23,7 +23,7 @@ public class RecommendTrail extends BaseEntity {
     private Theme theme;
 
     //TODO: 테마 입력
-    private enum Theme {
+    public enum Theme {
 
     }
 }

--- a/src/main/java/com/tm/gogo/domain/Terms.java
+++ b/src/main/java/com/tm/gogo/domain/Terms.java
@@ -27,7 +27,7 @@ public class Terms extends BaseEntity {
     private String detail;
 
     //TODO:약관 타입 입력
-    private enum Type {
+    public enum Type {
 
     }
 }

--- a/src/main/java/com/tm/gogo/domain/Youtube.java
+++ b/src/main/java/com/tm/gogo/domain/Youtube.java
@@ -20,7 +20,7 @@ public class Youtube extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Theme theme;
 
-    private enum Theme {
+    public enum Theme {
         INFO, VLOG
     }
 }


### PR DESCRIPTION
## Issue

- #30

## Description

QueryDSL 을 사용하기 위해 설정을 추가했습니다.

아래 코드처럼 동적 쿼리가 필요한 도메인은 별도 클래스를 만들어서 사용하면 됩니다.

```java
@Repository
@RequiredArgsConstructor
public class HikingTrailQueryRepository {

    private final JPAQueryFactory queryFactory;

    public List<HikingTrail> findByMountainCode(String mountainCode, Pageable pageable) {
        return queryFactory
                .selectFrom(hikingTrail)
                .where(hikingTrail.mountainCode.eq(mountainCode))
                .offset(pageable.getOffset())
                .limit(pageable.getPageSize())
                .fetch();
    }
}
```