### PR TITLE
feat: #29 등산로 조회 기능 추가

### DIFF
--- a/src/main/java/com/tm/gogo/HikingTrailRepository.java
+++ b/src/main/java/com/tm/gogo/HikingTrailRepository.java
@@ -1,7 +1,0 @@
-package com.tm.gogo;
-
-import com.tm.gogo.domain.hiking_trail.HikingTrail;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface HikingTrailRepository extends JpaRepository<HikingTrail, Long> {
-}

--- a/src/main/java/com/tm/gogo/config/SecurityConfig.java
+++ b/src/main/java/com/tm/gogo/config/SecurityConfig.java
@@ -62,8 +62,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/api/auth/**").permitAll()
                 .antMatchers("/api/members/me").hasRole("MEMBER")
                 .antMatchers("/api/members/terms").hasRole("MEMBER")
+                .antMatchers("/api/hiking-trails/favorite").hasRole("MEMBER")
                 .antMatchers(HttpMethod.GET, "/api/members/*").permitAll()
                 .antMatchers(HttpMethod.POST, "/api/members/**").permitAll()
+                .antMatchers(HttpMethod.GET, "/api/hiking-trails/**").permitAll()
                 .anyRequest().authenticated()   // 나머지 API 는 전부 인증 필요
 
                 // JwtFilter 를 addFilterBefore 로 등록했던 JwtSecurityConfig 클래스를 적용

--- a/src/main/java/com/tm/gogo/domain/favorite_trail/FavoriteTrail.java
+++ b/src/main/java/com/tm/gogo/domain/favorite_trail/FavoriteTrail.java
@@ -1,7 +1,9 @@
-package com.tm.gogo.domain;
+package com.tm.gogo.domain.favorite_trail;
 
+import com.tm.gogo.domain.BaseEntity;
 import com.tm.gogo.domain.hiking_trail.HikingTrail;
 import com.tm.gogo.domain.member.Member;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
@@ -21,4 +23,10 @@ public class FavoriteTrail extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "hiking_trail_id")
     private HikingTrail hikingTrail;
+
+    @Builder
+    public FavoriteTrail(Member member, HikingTrail hikingTrail) {
+        this.member = member;
+        this.hikingTrail = hikingTrail;
+    }
 }

--- a/src/main/java/com/tm/gogo/domain/favorite_trail/FavoriteTrailRepository.java
+++ b/src/main/java/com/tm/gogo/domain/favorite_trail/FavoriteTrailRepository.java
@@ -1,0 +1,6 @@
+package com.tm.gogo.domain.favorite_trail;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FavoriteTrailRepository extends JpaRepository<FavoriteTrail, Long> {
+}

--- a/src/main/java/com/tm/gogo/domain/hiking_trail/Difficulty.java
+++ b/src/main/java/com/tm/gogo/domain/hiking_trail/Difficulty.java
@@ -1,0 +1,5 @@
+package com.tm.gogo.domain.hiking_trail;
+
+public enum Difficulty {
+    EASY, NORMAL, HARD
+}

--- a/src/main/java/com/tm/gogo/domain/hiking_trail/HikingTrail.java
+++ b/src/main/java/com/tm/gogo/domain/hiking_trail/HikingTrail.java
@@ -22,38 +22,61 @@ public class HikingTrail {
     private String name;
 
     @Column(name = "length")
-    private Integer length;
+    private Integer length; // m 단위
 
     @Enumerated(EnumType.STRING)
     @Column(name = "difficulty")
     private Difficulty difficulty;
 
     @Column(name = "uptime")
-    private Integer uptime;
+    private Integer uptime; // 분
 
     @Column(name = "downtime")
-    private Integer downtime;
+    private Integer downtime;   // 분
+
+    @Column(name = "total_time")
+    private Integer totalTime;  // 분
 
     @Column(name = "mountain_code")
     private String mountainCode;
 
-    @Column(name = "image_url")
-    private String imageUrl;
+    @Column(name = "address")
+    private String address;
 
-    @OneToMany(mappedBy = "hikingTrail", cascade = CascadeType.REMOVE)
-    private List<Geometry> geometries = new ArrayList<>();
+    @Column(name = "favorite_count")
+    private Long favoriteCount;
 
-    public enum Difficulty {
-        EASY, NORMAL, HARD
-    }
+    @OneToOne(mappedBy = "hikingTrail", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, fetch = FetchType.LAZY)
+    private HikingTrailImage image;
+
+    @OneToMany(mappedBy = "hikingTrail", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, fetch = FetchType.LAZY)
+    private final List<Geometry> geometries = new ArrayList<>();
 
     @Builder
-    public HikingTrail(String name, Integer length, Difficulty difficulty, Integer uptime, Integer downtime, String mountainCode) {
+    public HikingTrail(String name, Integer length, Difficulty difficulty, Integer uptime, Integer downtime, String address) {
         this.name = name;
         this.length = length;
         this.difficulty = difficulty;
         this.uptime = uptime;
         this.downtime = downtime;
-        this.mountainCode = mountainCode;
+        this.totalTime = uptime + downtime;
+        this.address = address;
+        this.favoriteCount = 0L;
+    }
+
+    public void setImage(HikingTrailImage image) {
+        this.image = image;
+    }
+
+    public void addGeometry(Geometry geometry) {
+        this.geometries.add(geometry);
+    }
+
+    public String getImageUrl() {
+        return image != null ? image.getUrl() : null;
+    }
+
+    public void increaseFavoriteCount() {
+        this.favoriteCount += 1;
     }
 }

--- a/src/main/java/com/tm/gogo/domain/hiking_trail/HikingTrailImage.java
+++ b/src/main/java/com/tm/gogo/domain/hiking_trail/HikingTrailImage.java
@@ -9,27 +9,23 @@ import javax.persistence.*;
 @Getter
 @Entity
 @NoArgsConstructor
-@Table(name = "geometry")
-public class Geometry {
+@Table(name = "hiking_trail_image")
+public class HikingTrailImage {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "geometry_id")
+    @Column(name = "hiking_trail_image_id")
     private Long id;
 
-    @Column(name = "latitude")
-    private String latitude;
+    @Column(name = "url")
+    private String url;
 
-    @Column(name = "longitude")
-    private String longitude;
-
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "hiking_trail_id")
     private HikingTrail hikingTrail;
 
     @Builder
-    public Geometry(String latitude, String longitude, HikingTrail hikingTrail) {
-        this.latitude = latitude;
-        this.longitude = longitude;
+    public HikingTrailImage(String url, HikingTrail hikingTrail) {
+        this.url = url;
         this.hikingTrail = hikingTrail;
     }
 }

--- a/src/main/java/com/tm/gogo/domain/hiking_trail/HikingTrailQueryRepository.java
+++ b/src/main/java/com/tm/gogo/domain/hiking_trail/HikingTrailQueryRepository.java
@@ -1,0 +1,72 @@
+package com.tm.gogo.domain.hiking_trail;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tm.gogo.parameter.Scrollable;
+import com.tm.gogo.web.hiking_trail.HikingTrailCondition;
+import com.tm.gogo.web.hiking_trail.HikingTrailDto;
+import com.tm.gogo.web.hiking_trail.HikingTrailsResponse;
+import com.tm.gogo.web.hiking_trail.QHikingTrailDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+import static com.tm.gogo.domain.hiking_trail.QHikingTrail.hikingTrail;
+
+@Repository
+@RequiredArgsConstructor
+public class HikingTrailQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public HikingTrailsResponse findHikingTrails(HikingTrailCondition condition, Scrollable scrollable) {
+        List<HikingTrailDto> results = queryFactory
+                .select(new QHikingTrailDto(
+                        hikingTrail.id,
+                        hikingTrail.image.url,
+                        hikingTrail.name
+                ))
+                .from(hikingTrail)
+                .leftJoin(hikingTrail.image)
+                .where(
+                        greaterThanId(scrollable.getLastId()),
+                        containsAddress(condition.getAddress()),
+                        eqDifficulty(condition.getDifficulty()),
+                        lessOrEqLength(condition.getLength()),
+                        lessOrEqTime(condition.getTime())
+                )
+                .orderBy(condition.getOrder().getOrderSpecifier())
+                .limit(scrollable.getSize() + 1)
+                .fetch();
+
+        return toResponse(results, scrollable);
+    }
+
+    private HikingTrailsResponse toResponse(List<HikingTrailDto> results, Scrollable scrollable) {
+        boolean hasNext = results.size() > scrollable.getSize();
+        List<HikingTrailDto> contents = hasNext ? results.subList(0, scrollable.getSize()) : results;
+        return new HikingTrailsResponse(contents, hasNext);
+    }
+
+    private BooleanExpression greaterThanId(Long id) {
+        return id != null ? hikingTrail.id.gt(id) : null;
+    }
+
+    private BooleanExpression containsAddress(String address) {
+        return StringUtils.hasText(address) ? hikingTrail.address.contains(address) : null;
+    }
+
+    private BooleanExpression eqDifficulty(Difficulty difficulty) {
+        return difficulty != null ? hikingTrail.difficulty.eq(difficulty) : null;
+    }
+
+    private BooleanExpression lessOrEqLength(Integer length) {
+        return length != null ? hikingTrail.length.loe(length) : null;
+    }
+
+    private BooleanExpression lessOrEqTime(Integer totalTime) {
+        return totalTime != null ? hikingTrail.totalTime.loe(totalTime) : null;
+    }
+}

--- a/src/main/java/com/tm/gogo/domain/hiking_trail/HikingTrailQueryRepository.java
+++ b/src/main/java/com/tm/gogo/domain/hiking_trail/HikingTrailQueryRepository.java
@@ -13,6 +13,7 @@ import org.springframework.util.StringUtils;
 
 import java.util.List;
 
+import static com.tm.gogo.domain.favorite_trail.QFavoriteTrail.favoriteTrail;
 import static com.tm.gogo.domain.hiking_trail.QHikingTrail.hikingTrail;
 
 @Repository
@@ -31,6 +32,31 @@ public class HikingTrailQueryRepository {
                 .from(hikingTrail)
                 .leftJoin(hikingTrail.image)
                 .where(
+                        greaterThanId(scrollable.getLastId()),
+                        containsAddress(condition.getAddress()),
+                        eqDifficulty(condition.getDifficulty()),
+                        lessOrEqLength(condition.getLength()),
+                        lessOrEqTime(condition.getTime())
+                )
+                .orderBy(condition.getOrder().getOrderSpecifier())
+                .limit(scrollable.getSize() + 1)
+                .fetch();
+
+        return toResponse(results, scrollable);
+    }
+
+    public HikingTrailsResponse findFavoriteHikingTrails(Long memberId, HikingTrailCondition condition, Scrollable scrollable) {
+        List<HikingTrailDto> results = queryFactory
+                .select(new QHikingTrailDto(
+                        hikingTrail.id,
+                        hikingTrail.image.url,
+                        hikingTrail.name
+                ))
+                .from(favoriteTrail)
+                .join(favoriteTrail.hikingTrail, hikingTrail)
+                .leftJoin(hikingTrail.image)
+                .where(
+                        favoriteTrail.member.id.eq(memberId),
                         greaterThanId(scrollable.getLastId()),
                         containsAddress(condition.getAddress()),
                         eqDifficulty(condition.getDifficulty()),

--- a/src/main/java/com/tm/gogo/domain/hiking_trail/HikingTrailRepository.java
+++ b/src/main/java/com/tm/gogo/domain/hiking_trail/HikingTrailRepository.java
@@ -1,0 +1,6 @@
+package com.tm.gogo.domain.hiking_trail;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HikingTrailRepository extends JpaRepository<HikingTrail, Long> {
+}

--- a/src/main/java/com/tm/gogo/domain/hiking_trail/HikingTrailService.java
+++ b/src/main/java/com/tm/gogo/domain/hiking_trail/HikingTrailService.java
@@ -26,8 +26,8 @@ public class HikingTrailService {
         return hikingTrailQueryRepository.findHikingTrails(condition, scrollable);
     }
 
-    public List<HikingTrailDto> findFavoriteHikingTrails(Long memberId) {
-        return null;
+    public HikingTrailsResponse findFavoriteHikingTrails(Long memberId, HikingTrailCondition condition, Scrollable scrollable) {
+        return hikingTrailQueryRepository.findFavoriteHikingTrails(memberId, condition, scrollable);
     }
 
     public HikingTrailDetailResponse findHikingTrail(Long hikingTrailId) {

--- a/src/main/java/com/tm/gogo/domain/hiking_trail/HikingTrailService.java
+++ b/src/main/java/com/tm/gogo/domain/hiking_trail/HikingTrailService.java
@@ -1,0 +1,38 @@
+package com.tm.gogo.domain.hiking_trail;
+
+import com.tm.gogo.parameter.Scrollable;
+import com.tm.gogo.web.hiking_trail.HikingTrailCondition;
+import com.tm.gogo.web.hiking_trail.HikingTrailDetailResponse;
+import com.tm.gogo.web.hiking_trail.HikingTrailDto;
+import com.tm.gogo.web.hiking_trail.HikingTrailsResponse;
+import com.tm.gogo.web.response.ApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.tm.gogo.web.response.ErrorCode.HIKING_TRAIL_NOT_FOUND;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class HikingTrailService {
+
+    private final HikingTrailQueryRepository hikingTrailQueryRepository;
+    private final HikingTrailRepository hikingTrailRepository;
+
+    public HikingTrailsResponse findHikingTrails(HikingTrailCondition condition, Scrollable scrollable) {
+        return hikingTrailQueryRepository.findHikingTrails(condition, scrollable);
+    }
+
+    public List<HikingTrailDto> findFavoriteHikingTrails(Long memberId) {
+        return null;
+    }
+
+    public HikingTrailDetailResponse findHikingTrail(Long hikingTrailId) {
+        return hikingTrailRepository.findById(hikingTrailId)
+                .map(HikingTrailDetailResponse::of)
+                .orElseThrow(() -> new ApiException(HIKING_TRAIL_NOT_FOUND, "등산로 정보가 없습니다. hikingTrailId: " + hikingTrailId));
+    }
+}

--- a/src/main/java/com/tm/gogo/hikingLog/HikingLogImageRepository.java
+++ b/src/main/java/com/tm/gogo/hikingLog/HikingLogImageRepository.java
@@ -1,6 +1,0 @@
-package com.tm.gogo.hikingLog;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface HikingLogImageRepository extends JpaRepository<HikingLogImage, Long> {
-}

--- a/src/main/java/com/tm/gogo/hikingLog/HikingLogService.java
+++ b/src/main/java/com/tm/gogo/hikingLog/HikingLogService.java
@@ -1,7 +1,7 @@
 package com.tm.gogo.hikingLog;
 
-import com.tm.gogo.HikingTrailRepository;
 import com.tm.gogo.domain.hiking_trail.HikingTrail;
+import com.tm.gogo.domain.hiking_trail.HikingTrailRepository;
 import com.tm.gogo.domain.member.Member;
 import com.tm.gogo.domain.member.MemberRepository;
 import com.tm.gogo.web.hikingLog.HikingLogRequest;
@@ -19,7 +19,6 @@ public class HikingLogService {
     private final HikingLogRepository hikingLogRepository;
     private final HikingTrailRepository hikingTrailRepository;
     private final MemberRepository memberRepository;
-    private final HikingLogImageRepository hikingLogImageRepository;
 
     @Transactional
     public Long createHikingLog(Long memberId, HikingLogRequest hikingLogRequest) {

--- a/src/main/java/com/tm/gogo/parameter/Scrollable.java
+++ b/src/main/java/com/tm/gogo/parameter/Scrollable.java
@@ -1,0 +1,21 @@
+package com.tm.gogo.parameter;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Scrollable {
+
+    @Schema(example = "0", description = "마지막으로 조회한 ID")
+    private Long lastId;
+
+    @Schema(example = "3", description = "가져오려는 갯수")
+    private Integer size;
+
+    public int getSize() {
+        return size != null ? size : 20;
+    }
+}

--- a/src/main/java/com/tm/gogo/web/hiking_trail/GeometryDto.java
+++ b/src/main/java/com/tm/gogo/web/hiking_trail/GeometryDto.java
@@ -1,0 +1,24 @@
+package com.tm.gogo.web.hiking_trail;
+
+import com.tm.gogo.domain.hiking_trail.Geometry;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GeometryDto {
+
+    @Schema(example = "37.22589972640079")
+    private String latitude;
+
+    @Schema(example = "128.44706436148968")
+    private String longitude;
+
+    public static GeometryDto of(Geometry geometry) {
+        return GeometryDto.builder()
+                .latitude(geometry.getLatitude())
+                .longitude(geometry.getLongitude())
+                .build();
+    }
+}

--- a/src/main/java/com/tm/gogo/web/hiking_trail/HikingTrailCondition.java
+++ b/src/main/java/com/tm/gogo/web/hiking_trail/HikingTrailCondition.java
@@ -1,0 +1,32 @@
+package com.tm.gogo.web.hiking_trail;
+
+import com.tm.gogo.domain.hiking_trail.Difficulty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HikingTrailCondition {
+
+    @Schema(example = "서울", description = "지역 (전국이면 null 값으로 요청)")
+    private String address;
+
+    @Schema(example = "EASY", description = "난이도 (EASY, NORMAL, HARD)")
+    private Difficulty difficulty;
+
+    @Schema(example = "2500", description = "단위: m - 구간거리 (길이)")
+    private Integer length;
+
+    @Schema(example = "120", description = "단위: 분 - 평균소요시간 (상행시간 + 하행시간)")
+    private Integer time;
+
+    @Schema(example = "POPULARITY", description = "정렬 기준 (POPULARITY, LONG, SHORT)")
+    private HikingTrailOrder order;
+
+    public HikingTrailOrder getOrder() {
+        return order != null ? order : HikingTrailOrder.POPULARITY;
+    }
+}

--- a/src/main/java/com/tm/gogo/web/hiking_trail/HikingTrailController.java
+++ b/src/main/java/com/tm/gogo/web/hiking_trail/HikingTrailController.java
@@ -32,9 +32,9 @@ public class HikingTrailController {
 
     @Operation(summary = "즐겨찾기에 등록된 등산로 리스트 조회", description = "로그인 상태여야 하며 파라미터를 통해 필터링, 정렬 가능")
     @GetMapping("/favorite")
-    public ResponseEntity<List<HikingTrailDto>> findFavoriteHikingTrails() {
+    public ResponseEntity<HikingTrailsResponse> findFavoriteHikingTrails(HikingTrailCondition condition, Scrollable scrollable) {
         return ResponseEntity.ok(
-                hikingTrailService.findFavoriteHikingTrails(SecurityUtil.getCurrentMemberId())
+                hikingTrailService.findFavoriteHikingTrails(SecurityUtil.getCurrentMemberId(), condition, scrollable)
         );
     }
 

--- a/src/main/java/com/tm/gogo/web/hiking_trail/HikingTrailController.java
+++ b/src/main/java/com/tm/gogo/web/hiking_trail/HikingTrailController.java
@@ -1,0 +1,53 @@
+package com.tm.gogo.web.hiking_trail;
+
+import com.tm.gogo.domain.hiking_trail.HikingTrailService;
+import com.tm.gogo.helper.SecurityUtil;
+import com.tm.gogo.parameter.Scrollable;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "/hiking-trails", description = "등산로 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/hiking-trails")
+public class HikingTrailController {
+
+    private final HikingTrailService hikingTrailService;
+
+    @Operation(summary = "등산로 리스트 조회", description = "파라미터를 통해 필터링, 정렬 가능")
+    @GetMapping
+    public ResponseEntity<HikingTrailsResponse> findHikingTrails(HikingTrailCondition condition, Scrollable scrollable) {
+        return ResponseEntity.ok(
+                hikingTrailService.findHikingTrails(condition, scrollable)
+        );
+    }
+
+    @Operation(summary = "즐겨찾기에 등록된 등산로 리스트 조회", description = "로그인 상태여야 하며 파라미터를 통해 필터링, 정렬 가능")
+    @GetMapping("/favorite")
+    public ResponseEntity<List<HikingTrailDto>> findFavoriteHikingTrails() {
+        return ResponseEntity.ok(
+                hikingTrailService.findFavoriteHikingTrails(SecurityUtil.getCurrentMemberId())
+        );
+    }
+
+
+    @Operation(summary = "등산로 하나 조회", description = "등산로 한개에 대해 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "등산로 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "등산로 정보가 존재하지 않음", content = @Content)
+    })
+    @GetMapping("/{hikingTrailId}")
+    public ResponseEntity<HikingTrailDetailResponse> findHikingTrail(@PathVariable Long hikingTrailId) {
+        return ResponseEntity.ok(
+                hikingTrailService.findHikingTrail(hikingTrailId)
+        );
+    }
+}

--- a/src/main/java/com/tm/gogo/web/hiking_trail/HikingTrailDetailResponse.java
+++ b/src/main/java/com/tm/gogo/web/hiking_trail/HikingTrailDetailResponse.java
@@ -1,0 +1,51 @@
+package com.tm.gogo.web.hiking_trail;
+
+import com.tm.gogo.domain.hiking_trail.Difficulty;
+import com.tm.gogo.domain.hiking_trail.HikingTrail;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class HikingTrailDetailResponse {
+
+    @Schema(example = "관악산 A코스")
+    private String name;
+
+    @Schema(example = "서울시 강남구 대치동")
+    private String address;
+
+    @Schema(example = "EASY")
+    private Difficulty difficulty;
+
+    @Schema(example = "123", description = "단위: m")
+    private Integer length;
+
+    @Schema(example = "1", description = "단위: 분")
+    private Integer uptime;
+
+    @Schema(example = "2", description = "단위: 분")
+    private Integer downtime;
+
+    @Schema(example = "https://www.forest.go.kr/images/data/down/mountain/mountain_image.jpg")
+    private String imageUrl;
+
+    private List<GeometryDto> geometries;
+
+    public static HikingTrailDetailResponse of(HikingTrail hikingTrail) {
+        return HikingTrailDetailResponse.builder()
+                .name(hikingTrail.getName())
+                .address(hikingTrail.getAddress())
+                .difficulty(hikingTrail.getDifficulty())
+                .length(hikingTrail.getLength())
+                .uptime(hikingTrail.getUptime())
+                .downtime(hikingTrail.getDowntime())
+                .imageUrl(hikingTrail.getImageUrl())
+                .geometries(hikingTrail.getGeometries().stream().map(GeometryDto::of).collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/com/tm/gogo/web/hiking_trail/HikingTrailDto.java
+++ b/src/main/java/com/tm/gogo/web/hiking_trail/HikingTrailDto.java
@@ -1,0 +1,27 @@
+package com.tm.gogo.web.hiking_trail;
+
+import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class HikingTrailDto {
+
+    @Schema(example = "1")
+    private Long id;
+
+    @Schema(example = "https://www.forest.go.kr/images/data/down/mountain/mountain_image.jpg")
+    private String imageUrl;
+
+    @Schema(example = "관악산 A코스")
+    private String name;
+
+    @QueryProjection
+    public HikingTrailDto(Long id, String imageUrl, String name) {
+        this.id = id;
+        this.imageUrl = imageUrl;
+        this.name = name;
+    }
+}

--- a/src/main/java/com/tm/gogo/web/hiking_trail/HikingTrailOrder.java
+++ b/src/main/java/com/tm/gogo/web/hiking_trail/HikingTrailOrder.java
@@ -1,0 +1,18 @@
+package com.tm.gogo.web.hiking_trail;
+
+import com.querydsl.core.types.OrderSpecifier;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import static com.tm.gogo.domain.hiking_trail.QHikingTrail.hikingTrail;
+
+@Getter
+@RequiredArgsConstructor
+public enum HikingTrailOrder {
+    POPULARITY(hikingTrail.favoriteCount.desc()),
+    LONG(hikingTrail.length.desc()),
+    SHORT(hikingTrail.length.asc())
+    ;
+
+    private final OrderSpecifier<?> orderSpecifier;
+}

--- a/src/main/java/com/tm/gogo/web/hiking_trail/HikingTrailsResponse.java
+++ b/src/main/java/com/tm/gogo/web/hiking_trail/HikingTrailsResponse.java
@@ -1,0 +1,19 @@
+package com.tm.gogo.web.hiking_trail;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class HikingTrailsResponse {
+
+    private List<HikingTrailDto> contents;
+
+    @Schema(example = "true", description = "다음 데이터가 있는지 없는지 표시")
+    private boolean hasNext;
+}

--- a/src/test/java/com/tm/gogo/service/HikingLogServiceTest.java
+++ b/src/test/java/com/tm/gogo/service/HikingLogServiceTest.java
@@ -1,7 +1,7 @@
 package com.tm.gogo.service;
 
-import com.tm.gogo.HikingTrailRepository;
 import com.tm.gogo.domain.hiking_trail.HikingTrail;
+import com.tm.gogo.domain.hiking_trail.HikingTrailRepository;
 import com.tm.gogo.domain.member.Member;
 import com.tm.gogo.domain.member.MemberRepository;
 import com.tm.gogo.hikingLog.*;
@@ -34,9 +34,6 @@ public class HikingLogServiceTest {
 
     @Autowired
     private HikingTrailRepository hikingTrailRepository;
-
-    @Autowired
-    private HikingLogImageRepository hikingLogImageRepository;
 
     @DisplayName("HikingLog 생성 성공")
     @Test

--- a/src/test/java/com/tm/gogo/service/HikingTrailServiceTest.java
+++ b/src/test/java/com/tm/gogo/service/HikingTrailServiceTest.java
@@ -1,0 +1,318 @@
+package com.tm.gogo.service;
+
+import com.tm.gogo.domain.hiking_trail.*;
+import com.tm.gogo.parameter.Scrollable;
+import com.tm.gogo.web.hiking_trail.*;
+import com.tm.gogo.web.response.ApiException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+public class HikingTrailServiceTest {
+
+    @Autowired
+    private HikingTrailService hikingTrailService;
+
+    @Autowired
+    private HikingTrailRepository hikingTrailRepository;
+
+    @Nested
+    @DisplayName("등산로 조회")
+    class FindTest {
+
+        @BeforeEach
+        void setup() {
+            for (int i = 0; i < 10; i++) {
+                HikingTrail hikingTrail = createHikingTrail("등산로", 1000, Difficulty.EASY, 28, 32, "서울시 강남구 대치동");
+                hikingTrailRepository.saveAndFlush(hikingTrail);
+            }
+        }
+
+        @Test
+        @DisplayName("전체 등산로 리스트 조회")
+        void testFindHikingTrails() {
+            // when
+            HikingTrailsResponse responses = hikingTrailService.findHikingTrails(new HikingTrailCondition(), new Scrollable());
+
+            // then
+            assertThat(responses.getContents().size()).isEqualTo(10);
+        }
+
+        @Test
+        @DisplayName("필터링 - 지역 강원")
+        void testFindHikingTrailsFilterByAddress() {
+            // given
+            for (int i = 0; i < 5; i++) {
+                HikingTrail hikingTrail = createHikingTrail("등산로", 0, Difficulty.EASY, 0, 0, "강원도 속초시 중앙동");
+                hikingTrailRepository.saveAndFlush(hikingTrail);
+            }
+
+            // when
+            HikingTrailsResponse allResponses = hikingTrailService.findHikingTrails(new HikingTrailCondition(), new Scrollable());
+            HikingTrailsResponse responses = hikingTrailService.findHikingTrails(
+                    HikingTrailCondition.builder().address("강원").build(),
+                    new Scrollable()
+            );
+
+            // then
+            assertThat(allResponses.getContents().size()).isEqualTo(15);
+            assertThat(responses.getContents().size()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("필터링 - 난이도 어려움")
+        void testFindHikingTrailsFilterByDifficulty() {
+            // given
+            for (int i = 0; i < 5; i++) {
+                HikingTrail hikingTrail = createHikingTrail("등산로", 0, Difficulty.HARD, 0, 0, "서울시 강남구 대치동");
+                hikingTrailRepository.saveAndFlush(hikingTrail);
+            }
+
+            // when
+            HikingTrailsResponse allResponses = hikingTrailService.findHikingTrails(new HikingTrailCondition(), new Scrollable());
+            HikingTrailsResponse responses = hikingTrailService.findHikingTrails(
+                    HikingTrailCondition.builder().difficulty(Difficulty.HARD).build(),
+                    new Scrollable()
+            );
+
+            // then
+            assertThat(allResponses.getContents().size()).isEqualTo(15);
+            assertThat(responses.getContents().size()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("필터링 - 구간거리 0.5km")
+        void testFindHikingTrailsFilterByLength() {
+            // given
+            for (int i = 0; i < 5; i++) {
+                HikingTrail hikingTrail = createHikingTrail("등산로", 500, Difficulty.EASY, 0, 0, "강원도 속초시 중앙동");
+                hikingTrailRepository.saveAndFlush(hikingTrail);
+            }
+
+            // when
+            HikingTrailsResponse allResponses = hikingTrailService.findHikingTrails(new HikingTrailCondition(), new Scrollable());
+            HikingTrailsResponse responses = hikingTrailService.findHikingTrails(
+                    HikingTrailCondition.builder().length(500).build(),
+                    new Scrollable()
+            );
+
+            // then
+            assertThat(allResponses.getContents().size()).isEqualTo(15);
+            assertThat(responses.getContents().size()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("필터링 - 평균 소요시간 (상행속도 + 하행속도)")
+        void testFindHikingTrailsFilterByTime() {
+            // given
+            for (int i = 0; i < 5; i++) {
+                HikingTrail hikingTrail = createHikingTrail("등산로", 500, Difficulty.EASY, 14, 16, "강원도 속초시 중앙동");
+                hikingTrailRepository.saveAndFlush(hikingTrail);
+            }
+
+            // when
+            HikingTrailsResponse allResponses = hikingTrailService.findHikingTrails(new HikingTrailCondition(), new Scrollable());
+            HikingTrailsResponse responses = hikingTrailService.findHikingTrails(
+                    HikingTrailCondition.builder().time(30).build(),
+                    new Scrollable()
+            );
+
+            // then
+            assertThat(allResponses.getContents().size()).isEqualTo(15);
+            assertThat(responses.getContents().size()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("다중 필터링 - 지역 강원, 난이도 어려움")
+        void testFindByMultipleFilter() {
+            // given
+            for (int i = 0; i < 5; i++) {
+                HikingTrail hikingTrail = createHikingTrail("등산로", 0, Difficulty.HARD, 0, 0, "서울시 강남구 대치동");
+                hikingTrailRepository.saveAndFlush(hikingTrail);
+            }
+
+            for (int i = 0; i < 3; i++) {
+                HikingTrail hikingTrail = createHikingTrail("등산로", 0, Difficulty.HARD, 0, 0, "강원도 속초시 중앙동");
+                hikingTrailRepository.saveAndFlush(hikingTrail);
+            }
+
+            // when
+            HikingTrailsResponse allResponses = hikingTrailService.findHikingTrails(new HikingTrailCondition(), new Scrollable());
+            HikingTrailsResponse hardResponses = hikingTrailService.findHikingTrails(
+                    HikingTrailCondition.builder().difficulty(Difficulty.HARD).build(),
+                    new Scrollable()
+            );
+            HikingTrailsResponse seoulResponses = hikingTrailService.findHikingTrails(
+                    HikingTrailCondition.builder().address("서울").build(),
+                    new Scrollable()
+            );
+            HikingTrailsResponse multiResponses = hikingTrailService.findHikingTrails(
+                    HikingTrailCondition.builder().difficulty(Difficulty.HARD).address("서울").build(),
+                    new Scrollable()
+            );
+
+            // then
+            assertThat(allResponses.getContents().size()).isEqualTo(18);
+            assertThat(hardResponses.getContents().size()).isEqualTo(8);
+            assertThat(seoulResponses.getContents().size()).isEqualTo(15);
+            assertThat(multiResponses.getContents().size()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("정렬 - 인기순: 즐겨찾기 많이 된 순")
+        void testFindOrderByFavorite() {
+            // given
+            for (int i = 1; i < 6; i++) {
+                HikingTrail hikingTrail = createHikingTrail("등산로" + i, 0, Difficulty.HARD, 0, 0, "서울시 강남구 대치동");
+                for (int j = 0; j < i; j++) {
+                    hikingTrail.increaseFavoriteCount();
+                }
+                hikingTrailRepository.saveAndFlush(hikingTrail);
+            }
+
+            // when
+            HikingTrailsResponse responses = hikingTrailService.findHikingTrails(
+                    HikingTrailCondition.builder().order(HikingTrailOrder.POPULARITY).build(),
+                    new Scrollable()
+            );
+
+            // then
+            List<HikingTrailDto> contents = responses.getContents();
+            for (int i = 0; i < 5; i++) {
+                HikingTrailDto hikingTrailDto = contents.get(i);
+                assertThat(hikingTrailDto.getName()).isEqualTo("등산로" + (5 - i));
+            }
+        }
+
+        @Test
+        @DisplayName("정렬 - 길이 짧은 순")
+        void testFindOrderByLengthAsc() {
+            // given
+            for (int i = 1; i < 6; i++) {
+                HikingTrail hikingTrail = createHikingTrail("등산로" + i, 1000 - i, Difficulty.HARD, 0, 0, "서울시 강남구 대치동");
+                hikingTrailRepository.saveAndFlush(hikingTrail);
+            }
+
+            // when
+            HikingTrailsResponse responses = hikingTrailService.findHikingTrails(
+                    HikingTrailCondition.builder().order(HikingTrailOrder.SHORT).build(),
+                    new Scrollable()
+            );
+
+            // then
+            List<HikingTrailDto> contents = responses.getContents();
+            for (int i = 0; i < 5; i++) {
+                HikingTrailDto hikingTrailDto = contents.get(i);
+                assertThat(hikingTrailDto.getName()).isEqualTo("등산로" + (5 - i));
+            }
+        }
+
+        @Test
+        @DisplayName("정렬 - 길이 긴순")
+        void testFindOrderByLengthDesc() {
+            // given
+            for (int i = 1; i < 6; i++) {
+                HikingTrail hikingTrail = createHikingTrail("등산로" + i, 1000 + i, Difficulty.HARD, 0, 0, "서울시 강남구 대치동");
+                hikingTrailRepository.saveAndFlush(hikingTrail);
+            }
+
+            // when
+            HikingTrailsResponse responses = hikingTrailService.findHikingTrails(
+                    HikingTrailCondition.builder().order(HikingTrailOrder.LONG).build(),
+                    new Scrollable()
+            );
+
+            // then
+            List<HikingTrailDto> contents = responses.getContents();
+            for (int i = 0; i < 5; i++) {
+                HikingTrailDto hikingTrailDto = contents.get(i);
+                assertThat(hikingTrailDto.getName()).isEqualTo("등산로" + (5 - i));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("등산로 하나 조회")
+    class FindOne {
+
+        @Test
+        @DisplayName("조회 성공")
+        void testFindOne() {
+            // given
+            String name = "관악산 A코스";
+            Integer length = 123;
+            Difficulty difficulty = Difficulty.EASY;
+            Integer uptime = 1;
+            Integer downtime = 2;
+            String address = "서울시 강남구 대치동";
+            String imageUrl = "mountain_image.jpg";
+            String latitude = "37.22589972640079";
+            String longitude = "128.44706436148968";
+
+            HikingTrail hikingTrail = createHikingTrail(name, length, difficulty, uptime, downtime, address);
+
+            HikingTrailImage image = HikingTrailImage.builder()
+                    .url(imageUrl)
+                    .hikingTrail(hikingTrail)
+                    .build();
+            hikingTrail.setImage(image);
+
+            Geometry geometry = Geometry.builder()
+                    .latitude(latitude)
+                    .longitude(longitude)
+                    .hikingTrail(hikingTrail)
+                    .build();
+            hikingTrail.addGeometry(geometry);
+
+            hikingTrailRepository.saveAndFlush(hikingTrail);
+
+            // when
+            HikingTrailDetailResponse response = hikingTrailService.findHikingTrail(hikingTrail.getId());
+
+            // then
+            assertThat(response.getName()).isEqualTo(name);
+            assertThat(response.getLength()).isEqualTo(length);
+            assertThat(response.getDifficulty()).isEqualTo(difficulty);
+            assertThat(response.getUptime()).isEqualTo(uptime);
+            assertThat(response.getDowntime()).isEqualTo(downtime);
+            assertThat(response.getAddress()).isEqualTo(address);
+            assertThat(response.getImageUrl()).isEqualTo(imageUrl);
+
+            GeometryDto geometryDto = response.getGeometries().stream().findFirst().orElse(null);
+            assertThat(geometryDto).isNotNull();
+            assertThat(geometryDto.getLatitude()).isEqualTo(latitude);
+            assertThat(geometryDto.getLongitude()).isEqualTo(longitude);
+        }
+
+        @Test
+        @DisplayName("등산로 데이터가 없어서 조회 실패")
+        void testFindFail() {
+            Long hikingTrailId = 1L;
+
+            assertThatExceptionOfType(ApiException.class)
+                    .isThrownBy(() -> hikingTrailService.findHikingTrail(hikingTrailId))
+                    .withMessage("등산로 정보가 없습니다. hikingTrailId: " + hikingTrailId);
+        }
+    }
+
+    private HikingTrail createHikingTrail(String name, Integer length, Difficulty difficulty, Integer uptime, Integer downtime, String address) {
+        return HikingTrail.builder()
+                .name(name)
+                .length(length)
+                .difficulty(difficulty)
+                .uptime(uptime)
+                .downtime(downtime)
+                .address(address)
+                .build();
+    }
+}


### PR DESCRIPTION
## Issue

- #29 

## Description

등산로 조회 기능입니다.

등산로 데이터는 이미 저장되어 있지만 필터, 정렬에 따라 데이터가 달라집니다.

- 정렬: 인기순(즐겨찾기 표시 개수순), 나와의 거리순, 거리 긴순, 거리 짧은 순
- 필터: 지역, 난이도, 거리, 소요시간

등산로 리스트는 여러개를 내려주고 사용자가 하나를 클릭할 때마다 id 를 받아 상세 정보를 내려줍니다.

<img width="50%" alt="image" src="https://user-images.githubusercontent.com/28972341/186481342-8eb96400-e4d5-4842-aea4-96c631b39836.png">

<img width="50%" alt="image" src="https://user-images.githubusercontent.com/28972341/186481386-32bf934a-ed39-49c3-aaf6-e3beb30297cc.png">
