### PR TITLE
refactor: #66 Member 조회 기능 MemberService 로 통일

### DIFF
--- a/src/main/java/com/tm/gogo/domain/favorite_trail/FavoriteTrailService.java
+++ b/src/main/java/com/tm/gogo/domain/favorite_trail/FavoriteTrailService.java
@@ -3,7 +3,7 @@ package com.tm.gogo.domain.favorite_trail;
 import com.tm.gogo.domain.hiking_trail.HikingTrail;
 import com.tm.gogo.domain.hiking_trail.HikingTrailRepository;
 import com.tm.gogo.domain.member.Member;
-import com.tm.gogo.domain.member.MemberRepository;
+import com.tm.gogo.domain.member.MemberService;
 import com.tm.gogo.web.response.ApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,12 +16,12 @@ import static com.tm.gogo.web.response.ErrorCode.*;
 @RequiredArgsConstructor
 public class FavoriteTrailService {
 
-    private final MemberRepository memberRepository;
+    private final MemberService memberService;
     private final HikingTrailRepository hikingTrailRepository;
     private final FavoriteTrailRepository favoriteTrailRepository;
 
     public void registerFavorite(Long memberId, Long hikingTrailId) {
-        Member member = findMember(memberId);
+        Member member = memberService.findMemberById(memberId);
         HikingTrail hikingTrail = findHikingTrail(hikingTrailId);
         validate(member, hikingTrail);
 
@@ -37,18 +37,13 @@ public class FavoriteTrailService {
     }
 
     public void deleteFavorite(Long memberId, Long hikingTrailId) {
-        Member member = findMember(memberId);
+        Member member = memberService.findMemberById(memberId);
         HikingTrail hikingTrail = findHikingTrail(hikingTrailId);
         FavoriteTrail favorite = favoriteTrailRepository.findByMemberAndHikingTrail(member, hikingTrail)
                 .orElseThrow(() -> new ApiException(FAVORITE_TRAIL_NOT_FOUND, "즐겨찾기 된 상태가 아닙니다. memberId: " + memberId + ", hikingTrailId: " + hikingTrailId));
 
         favorite.destroy();
         favoriteTrailRepository.delete(favorite);
-    }
-
-    private Member findMember(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND, "사용자 정보가 없습니다. memberId: " + memberId));
     }
 
     private HikingTrail findHikingTrail(Long hikingTrailId) {

--- a/src/main/java/com/tm/gogo/domain/hiking_log/HikingLogService.java
+++ b/src/main/java/com/tm/gogo/domain/hiking_log/HikingLogService.java
@@ -3,7 +3,7 @@ package com.tm.gogo.domain.hiking_log;
 import com.tm.gogo.domain.hiking_trail.HikingTrail;
 import com.tm.gogo.domain.hiking_trail.HikingTrailRepository;
 import com.tm.gogo.domain.member.Member;
-import com.tm.gogo.domain.member.MemberRepository;
+import com.tm.gogo.domain.member.MemberService;
 import com.tm.gogo.parameter.Scrollable;
 import com.tm.gogo.web.hiking_log.HikingLogDetailResponse;
 import com.tm.gogo.web.hiking_log.HikingLogDto;
@@ -23,26 +23,21 @@ import static com.tm.gogo.web.response.ErrorCode.*;
 @Service
 @RequiredArgsConstructor
 public class HikingLogService {
+    private final MemberService memberService;
     private final HikingLogRepository hikingLogRepository;
     private final HikingTrailRepository hikingTrailRepository;
-    private final MemberRepository memberRepository;
     private final HikingLogQueryRepository hikingLogQueryRepository;
     private final HikingLogImageQueryRepository hikingLogImageQueryRepository;
 
     @Transactional
     public Long createHikingLog(Long memberId, HikingLogRequest hikingLogRequest) {
-        Member member = findMemberByMemberId(memberId);
+        Member member = memberService.findMemberById(memberId);
         HikingTrail hikingTrail = findByHikingTrailId(hikingLogRequest.getHikingTrailId());
 
         HikingLog hikingLog = hikingLogRequest.toHikingLog(member, hikingTrail);
 
         hikingLogRepository.save(hikingLog);
         return hikingLog.getId();
-    }
-
-    private Member findMemberByMemberId(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND, "사용자 정보가 없습니다. memberId: " + memberId));
     }
 
     private HikingTrail findByHikingTrailId(Long hikingTrailId) {

--- a/src/main/java/com/tm/gogo/domain/hiking_trail/HikingTrailService.java
+++ b/src/main/java/com/tm/gogo/domain/hiking_trail/HikingTrailService.java
@@ -3,7 +3,7 @@ package com.tm.gogo.domain.hiking_trail;
 import com.tm.gogo.domain.favorite_trail.FavoriteTrail;
 import com.tm.gogo.domain.favorite_trail.FavoriteTrailRepository;
 import com.tm.gogo.domain.member.Member;
-import com.tm.gogo.domain.member.MemberRepository;
+import com.tm.gogo.domain.member.MemberService;
 import com.tm.gogo.parameter.Scrollable;
 import com.tm.gogo.web.hiking_trail.HikingTrailCondition;
 import com.tm.gogo.web.hiking_trail.HikingTrailDetailResponse;
@@ -18,16 +18,15 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.tm.gogo.web.response.ErrorCode.HIKING_TRAIL_NOT_FOUND;
-import static com.tm.gogo.web.response.ErrorCode.MEMBER_NOT_FOUND;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class HikingTrailService {
 
+    private final MemberService memberService;
     private final HikingTrailQueryRepository hikingTrailQueryRepository;
     private final HikingTrailRepository hikingTrailRepository;
-    private final MemberRepository memberRepository;
     private final FavoriteTrailRepository favoriteTrailRepository;
 
     public HikingTrailsResponse findHikingTrails(HikingTrailCondition condition, Scrollable scrollable) {
@@ -41,7 +40,7 @@ public class HikingTrailService {
     }
 
     private void updateFavorite(Long memberId, HikingTrailsResponse hikingTrails) {
-        Member member = findMember(memberId);
+        Member member = memberService.findMemberById(memberId);
 
         List<Long> hikingTrailIds = hikingTrails.getContents().stream()
                 .map(HikingTrailDto::getId)
@@ -65,10 +64,5 @@ public class HikingTrailService {
         return hikingTrailRepository.findById(hikingTrailId)
                 .map(HikingTrailDetailResponse::of)
                 .orElseThrow(() -> new ApiException(HIKING_TRAIL_NOT_FOUND, "등산로 정보가 없습니다. hikingTrailId: " + hikingTrailId));
-    }
-
-    private Member findMember(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND, "사용자 정보가 없습니다. memberId: " + memberId));
     }
 }

--- a/src/main/java/com/tm/gogo/domain/member/MemberService.java
+++ b/src/main/java/com/tm/gogo/domain/member/MemberService.java
@@ -27,7 +27,7 @@ public class MemberService {
     private final MailService mailService;
     private final PasswordEncoder passwordEncoder;
 
-    public MemberResponse findMemberById(Long memberId) {
+    public MemberResponse findMemberInfoById(Long memberId) {
         return memberRepository.findById(memberId)
                 .map(MemberResponse::of)
                 .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND, "사용자 정보가 없습니다. memberId: " + memberId));
@@ -63,14 +63,14 @@ public class MemberService {
                 .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND, "사용자 정보가 없습니다. email: " + email));
     }
 
-    private Member findById(Long memberId) {
+    public Member findMemberById(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND, "사용자 정보가 없습니다. memberId: " + memberId));
     }
 
     @Transactional
     public void update(Long memberId, MemberRequest memberRequest) {
-        Member member = findById(memberId);
+        Member member = findMemberById(memberId);
 
         boolean matches = passwordEncoder.matches(memberRequest.getPassword(), member.getPassword());
         if (!matches)

--- a/src/main/java/com/tm/gogo/domain/term_agreement/TermAgreementService.java
+++ b/src/main/java/com/tm/gogo/domain/term_agreement/TermAgreementService.java
@@ -1,8 +1,6 @@
 package com.tm.gogo.domain.term_agreement;
 
-import com.tm.gogo.domain.member.Member;
-import com.tm.gogo.domain.member.MemberRepository;
-import com.tm.gogo.web.response.ApiException;
+import com.tm.gogo.domain.member.MemberService;
 import com.tm.gogo.web.term_agreement.TermAgreementResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,28 +9,22 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.tm.gogo.web.response.ErrorCode.MEMBER_NOT_FOUND;
-
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class TermAgreementService {
 
-    private final MemberRepository memberRepository;
+    private final MemberService memberService;
+
 
     public List<TermAgreementResponse> findTermAgreements(Long memberId) {
-        return findMember(memberId).getTermAgreements().stream()
+        return memberService.findMemberById(memberId).getTermAgreements().stream()
                 .map(TermAgreementResponse::of)
                 .collect(Collectors.toList());
     }
 
     @Transactional
     public void updateTermAgreement(Long memberId, Term term, Boolean agreed) {
-        findMember(memberId).updateTermAgreed(term, agreed);
-    }
-
-    private Member findMember(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND, "사용자 정보가 없습니다. memberId: " + memberId));
+        memberService.findMemberById(memberId).updateTermAgreed(term, agreed);
     }
 }

--- a/src/main/java/com/tm/gogo/web/member/MemberController.java
+++ b/src/main/java/com/tm/gogo/web/member/MemberController.java
@@ -28,7 +28,7 @@ public class MemberController {
     })
     @GetMapping("/me")
     public ResponseEntity<MemberResponse> findMemberById() {
-        return ResponseEntity.ok(memberService.findMemberById(SecurityUtil.getCurrentMemberId()));
+        return ResponseEntity.ok(memberService.findMemberInfoById(SecurityUtil.getCurrentMemberId()));
     }
 
     @Operation(summary = "비밀번호 찾기 토큰 발급 요청", description = "토큰 검증을 위해 토큰 발행")

--- a/src/test/java/com/tm/gogo/service/MemberServiceTest.java
+++ b/src/test/java/com/tm/gogo/service/MemberServiceTest.java
@@ -54,7 +54,7 @@ public class MemberServiceTest {
             memberRepository.saveAndFlush(member);
 
             // when
-            MemberResponse memberResponse = memberService.findMemberById(member.getId());
+            MemberResponse memberResponse = memberService.findMemberInfoById(member.getId());
 
             // then
             assertThat(memberResponse.getEmail()).isEqualTo(email);
@@ -68,7 +68,7 @@ public class MemberServiceTest {
             Long memberId = 0L;
 
             assertThatExceptionOfType(ApiException.class)
-                    .isThrownBy(() -> memberService.findMemberById(memberId))
+                    .isThrownBy(() -> memberService.findMemberInfoById(memberId))
                     .withMessage("사용자 정보가 없습니다. memberId: " + memberId);
         }
     }


### PR DESCRIPTION
## Issue

<!--
Github Issue 번호
-->

- #66

## Changes

<!--
새로 추가하거나 수정된 내용 등등 주요 변경 사항 
-->

- 여러 서비스들이 MemberRepository 에서 직접 조회하고 있는데 MemberService 를 통해 조회하도록 변경
- 추후에 MemberService 에 뭔가를 추가할 때 순환 참조가 발생하지 않도록 주의 필요
